### PR TITLE
Fix getmsg timestamps

### DIFF
--- a/src/commands/getmsg.c
+++ b/src/commands/getmsg.c
@@ -82,7 +82,7 @@ struct discord_interaction_response command_getmsg(
         "User %s sent [message](https://discord.com/channels/%llu/%llu/%llu) <t:%llu:D><t:%llu:T>\n%s",
         message.author->username,
         message.guild_id, message.channel_id, message.id,
-        message.timestamp, message.timestamp,
+        message.timestamp / 1000, message.timestamp / 1000,
         message.content
     );
 


### PR DESCRIPTION
As noted in #1, getmsg was using timestamp from `discord_message.timestamp`, which in milliseconds.

This fix add dividing timestamp by 1000, so it will be in seconds now